### PR TITLE
Add Node.js 26 support

### DIFF
--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -1,0 +1,25 @@
+FROM cimg/node:26.4@sha256:7fb18a736147692189304d58fbec342569ab7b54dfa245a93dd14974041a1d6d
+
+RUN sudo apt-get update && \
+    sudo apt-get -y install gettext-base && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+# Install kiota (default version; consumers can override by installing a different version in their CI step)
+# renovate: datasource=github-releases depName=microsoft/kiota
+ENV KIOTA_VERSION=v1.30.0
+RUN curl -sSL https://github.com/microsoft/kiota/releases/download/${KIOTA_VERSION}/linux-x64.zip -o kiota.zip && \
+    sudo unzip -o kiota.zip -d /usr/local/bin && \
+    sudo chmod +x /usr/local/bin/kiota && \
+    rm -f kiota.zip
+
+# pnpm ships preinstalled on this base image — Node.js 26 dropped Corepack, so it can no longer be enabled here
+RUN pnpm config set store-dir .pnpm-store
+
+# Bun — run TypeScript in CI without a separate compile step (optional for consumers).
+# renovate: datasource=github-releases depName=oven-sh/bun
+ENV BUN_VERSION=1.3.10
+ENV BUN_INSTALL=/usr/local/bun
+ENV PATH="${BUN_INSTALL}/bin:${PATH}"
+RUN sudo mkdir -p "${BUN_INSTALL}" && sudo chown circleci:circleci "${BUN_INSTALL}" && \
+    curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" && \
+    bun --version

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ List of image tags:
 | Tag |    Based on     |                              Description                              |
 | :-: | :-------------: | :-------------------------------------------------------------------: |
 | 24  | cimg/node:24.14 | Node.js 24.14, pnpm (Corepack), **Bun**, Kiota, gettext-base. Supports buildx used by `aws-ecr` orb. |
+| 26  | cimg/node:26.4  | Node.js 26.4, pnpm/yarn (preinstalled — no Corepack), **Bun**, Kiota, gettext-base. Supports buildx used by `aws-ecr` orb. |
 
 ## pnpm (Corepack) and Bun
 
@@ -14,15 +15,16 @@ Both tools are installed on **`PATH`** for the default **`circleci`** user (Circ
 
 ### pnpm — default package manager
 
-- **How:** **Corepack** is enabled with **`--install-directory ~/bin`** (i.e. **`/home/circleci/bin`** on this image).
+- **How (tag 24):** **Corepack** is enabled with **`--install-directory ~/bin`** (i.e. **`/home/circleci/bin`** on this image).
 - **Why that directory:** Image layers run as **`circleci`**, not root. A plain **`corepack enable`** wants to write shims under **`/usr/local/bin`**, which is root-owned, so enabling Corepack for **`pnpm`**/`yarn` into **`~/bin`** avoids permission errors without relying on `sudo` in that step.
-- **What you run:** **`pnpm`** / **`pnpx`** from the pruned monorepo as usual. Version follows Corepack’s resolution (see `packageManager` in your repo).
+- **How (tag 26+):** Node.js dropped Corepack from the runtime starting with v25, so `cimg/node:26.x` ships **`pnpm`** and **`yarn`** preinstalled globally under **`/usr/local/bin`** instead — there is no Corepack step to run.
+- **What you run:** **`pnpm`** / **`pnpx`** from the pruned monorepo as usual. On tag 24, version follows Corepack’s resolution (see `packageManager` in your repo); on tag 26+, version follows whatever `cimg/node` bundles.
 
 ### Bun — optional TypeScript / tooling runtime
 
 - **How:** Official **[Bun](https://bun.sh)** install with **`BUN_INSTALL=/usr/local/bun`**; the directory is created and **`chown`’d** to **`circleci`** so the runtime can live under a fixed **`/usr/local/...`** path while still being writable by the job user.
 - **Why not `~/bin`:** Keeps Bun **separate** from Corepack’s shims in **`~/bin`**, avoids name clashes, and gives one obvious prefix (`/usr/local/bun`) for the binary and caches.
-- **What you run:** e.g. **`bun ./scripts/ci-task.ts`** without `tsc` or **`node --experimental-strip-types`**. Pin is **`BUN_VERSION`** in `24/Dockerfile` (Renovate: **`oven-sh/bun`**).
+- **What you run:** e.g. **`bun ./scripts/ci-task.ts`** without `tsc` or **`node --experimental-strip-types`**. Pin is **`BUN_VERSION`** in each version directory's `Dockerfile` (Renovate: **`oven-sh/bun`**).
 
 Bun does **not** replace pnpm for installing workspace dependencies unless your pipeline calls **`bun`** explicitly.
 


### PR DESCRIPTION
## Summary
- Add `26` image variant based on `cimg/node:26.4`
- Node.js dropped Corepack starting with v25, so this base image ships `pnpm`/`yarn` preinstalled globally instead — the `corepack enable` step is removed for this tag
- Update README to document the tag 24 (Corepack) vs tag 26+ (preinstalled pnpm/yarn) difference

## Test plan
- [x] `docker buildx build --platform linux/amd64 -t ci-image-nodejs:26 26` succeeds
- [x] Verified `node`, `pnpm`, `yarn`, `bun`, `kiota`, `gettext` all work inside the built image
